### PR TITLE
Update poap.py

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -279,9 +279,9 @@ import string
 # Will be used by set_config_file_src_location() function
 poap_log("INFO: show cdp neighbors interface %s" % cdp_interface)
 a = clid("show cdp neighbors interface %s" % cdp_interface)
-b = eval(a)
-cdpnei_switchName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['device_id']
-cdpnei_intfName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['port_id']
+b = json.loads(a)
+cdpnei_switchName = str(b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['device_id'])
+cdpnei_intfName = str(b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['port_id'])
 cdpnei_intfName = string.replace(cdpnei_intfName, "/", "_")
 
 # utility functions
@@ -543,4 +543,3 @@ install_it()
 
 poap_log_close()
 exit(0)
-

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -26,13 +26,13 @@ from cli import *
 # in your automation environment
 
 # system and kickstart images, configuration: location on server (src) and target (dst)
-n9k_image_version       = "6.1.2"
-image_dir_src           = "/tftpb"
+n9k_image_version       = "6.1.2" # this must match your code version
+image_dir_src           = "/tftpboot"  # Sample - /Users/bob/poap
 ftp_image_dir_src_root  = image_dir_src
 tftp_image_dir_src_root = image_dir_src
 n9k_system_image_src    = "n9000-dk9.%s.bin" % n9k_image_version
-config_file_src         = "/tftpb/poap.cfg" 
-image_dir_dst           = "bootflash:poap"
+config_file_src         = "/tftpboot/conf" # Sample - /Users/bob/poap/conf
+image_dir_dst           = "bootflash:poap" # directory where n9k image will be stored
 system_image_dst        = n9k_system_image_src
 config_file_dst         = "volatile:poap.cfg"
 md5sum_ext_src          = "md5"
@@ -44,10 +44,10 @@ required_space          = 350000
 protocol                = "scp" # protocol to use to download images/config
 
 # Host name and user credentials
-username                = "root" # tftp server account
-ftp_username            = "anonymous" # ftp server account
-password                = "root"
-hostname                = "1.1.1.1"
+username                = "root" # server account
+ftp_username            = "anonymous" # server account
+password                = "root" # password
+hostname                = "1.1.1.1" # ip address of ftp/scp/http/sftp server
 
 # vrf info
 vrf = "management"
@@ -65,7 +65,7 @@ md5sum_timeout          = 120
 # - 'location' - CDP neighbor of interface on which DHCPDISCOVER arrived
 #                is part of filename
 # if serial-number is abc, then filename is $config_file_src.abc
-# if cdp neighbor's device_id=abc and port_id=111, then filename is config_file_src.abc_111
+# if cdp neighbor's device_id=abc and port_id=111, then filename is config_file_src.abc.111
 # Note: the next line can be overwritten by command-line arg processing later
 config_file_type        = "static"
 
@@ -274,6 +274,15 @@ if not os.path.exists(image_dir_dst_u):
 
 import signal
 import string
+
+# Set CDP variables for location option
+# Will be used by set_config_file_src_location() function
+poap_log("INFO: show cdp neighbors interface %s" % cdp_interface)
+a = clid("show cdp neighbors interface %s" % cdp_interface)
+b = eval(a)
+cdpnei_switchName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['device_id']
+cdpnei_intfName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['port_id']
+cdpnei_intfName = string.replace(cdpnei_intfName, "/", "_")
 
 # utility functions
 
@@ -499,27 +508,35 @@ def verify_freespace ():
         poap_log("ERR : Not enough space to copy the config, kickstart image and system image, aborting!")
         abort_cleanup_exit()
 
+# figure out config filename to download based on CDP Neighbor information
+def set_config_file_src_location():
+    global config_file_src, cdpnei_switchName, cdpnei_intfName
+    config_file_src = "%s.%s.%s" % (config_file_src, cdpnei_switchName, cdpnei_intfName)
+    poap_log("INFO: Selected conf file name (location) : %s" % config_file_src)
 
 # figure out config filename to download based on serial-number
 def set_config_file_src_serial_number (): 
     global config_file_src
     config_file_src = "%s.%s" % (config_file_src, serial_number)
-    poap_log("INFO: Selected config filename (serial-nb) : %s" % config_file_src)
+    poap_log("INFO: Selected config filename (serial_number) : %s" % config_file_src)
 
+if config_file_type == "location":
+    # set source config file based on switch's location
+    set_config_file_src_location()
 
 if config_file_type == "serial_number": 
     #set source config file based on switch's serial number
     set_config_file_src_serial_number()
 
 
-# finaly do it
+# finally do it
 
 verify_freespace()
 get_system_image()
 verify_images()
 get_config()
 
-# dont let people abort the final stage that concretize everything
+# don't let people abort the final stage that concretize everything
 # not sure who would send such a signal though!!!! (sysmgr not known to care about vsh)
 signal.signal(signal.SIGTERM, sig_handler_no_exit)
 install_it()


### PR DESCRIPTION
# Completed the "location" code which allows for CDP neighbor information (switchName and              # IntfName) # to be appended to a filename.
# 
# If the location option is selected, the filename that the script expects will look like this:
# conf.MgmtSwitch01.FastEthernet0_3

# Set CDP variables for location option
# Will be used by set_config_file_src_location() function
poap_log("INFO: show cdp neighbors interface %s" % cdp_interface)
a = clid("show cdp neighbors interface %s" % cdp_interface)
b = eval(a)
cdpnei_switchName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['device_id']
cdpnei_intfName = b['TABLE_cdp_neighbor_brief_info']['ROW_cdp_neighbor_brief_info']['port_id']
cdpnei_intfName = string.replace(cdpnei_intfName, "/", "_")

# figure out config filename to download based on CDP Neighbor information
def set_config_file_src_location():
    global config_file_src, cdpnei_switchName, cdpnei_intfName
    config_file_src = "%s.%s.%s" % (config_file_src, cdpnei_switchName, cdpnei_intfName)
    poap_log("INFO: Selected conf file name (location) : %s" % config_file_src)

if config_file_type == "location":
    # set source config file based on switch's location
    set_config_file_src_location()