### PR TITLE
Minor change to MD5 update shell command

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -2,8 +2,8 @@
 #md5sum="a39fc249d01b49ddee8c119275eaace7"
 """
 If any changes are made to this script, please run the below command
-in bash shell to update the above md5sum. This is used for an integrity check.
-f=poap.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
+in bash shell to update the above md5sum. This is used for integrity check.
+f=poap_nexus_script.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
 "s/^#md5sum=.*/#md5sum=\"$(md5sum $f.md5 | sed 's/ .*//')\"/" $f
 """
 

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -200,10 +200,10 @@ def set_defaults_and_validate_options():
     # Transfer protocol (http, ftp, tftp, scp, etc.)
     set_default("transfer_protocol", "scp")
     # Directory where the config resides
-    set_default("config_path", "/var/lib/tftpboot/")
+    set_default("config_path", "/")
     # Target image and its path (single image is default)
     set_default("target_system_image", "")
-    set_default("target_image_path", "/var/lib/tftpboot/")
+    set_default("target_image_path", "/")
     set_default("target_kickstart_image", "")
     # Destination image and its path
     set_default("destination_path", "/bootflash/")
@@ -213,7 +213,7 @@ def set_defaults_and_validate_options():
     set_default("destination_midway_kickstart_image", "midway_kickstart.bin")
 
     # User app path
-    set_default("user_app_path", "/var/lib/tftpboot/")
+    set_default("user_app_path", "/")
 
     # MD5 Verification
     set_default("disable_md5", False)

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -2,8 +2,8 @@
 #md5sum="a39fc249d01b49ddee8c119275eaace7"
 """
 If any changes are made to this script, please run the below command
-in bash shell to update the above md5sum. This is used for integrity check.
-f=poap_nexus_script.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
+in bash shell to update the above md5sum. This is used for an integrity check.
+f=poap.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
 "s/^#md5sum=.*/#md5sum=\"$(md5sum $f.md5 | sed 's/ .*//')\"/" $f
 """
 


### PR DESCRIPTION
Since the filename is poap.py, it only makes sense to use the filename poap.py in the given bash shell script. That way, the user can copy out the line exactly and run it verbatim to update the MD5 hash in the file.