### PR TITLE
Update file transfer paths to saner defaults

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -200,10 +200,10 @@ def set_defaults_and_validate_options():
     # Transfer protocol (http, ftp, tftp, scp, etc.)
     set_default("transfer_protocol", "scp")
     # Directory where the config resides
-    set_default("config_path", "/var/lib/tftpboot/")
+    set_default("config_path", "/")
     # Target image and its path (single image is default)
     set_default("target_system_image", "")
-    set_default("target_image_path", "/var/lib/tftpboot/")
+    set_default("target_image_path", "/")
     set_default("target_kickstart_image", "")
     # Destination image and its path
     set_default("destination_path", "/bootflash/")
@@ -213,7 +213,7 @@ def set_defaults_and_validate_options():
     set_default("destination_midway_kickstart_image", "midway_kickstart.bin")
 
     # User app path
-    set_default("user_app_path", "/var/lib/tftpboot/")
+    set_default("user_app_path", "/")
 
     # MD5 Verification
     set_default("disable_md5", False)


### PR DESCRIPTION
Although "/var/lib/tftpboot" is the correct default directory for many TFTP servers, it's not the default path when files are copied from those servers. Many users are going to be using something like tftpd-hpa on Ubuntu. This (and many other SCP / FTP / TFTP clients) have their own root directory which is directly exposed when the user tries to copy. That is to say, if the user just copies from tftp@x.x.x.x/filename, they will, by default, be copying from /var/lib/tftpboot. We should put saner defaults into the script so that the user doesn't run into errors like this:

2017 Sep 27 17:53:00 switch %$ VDC-1 %$ %USER-1-SYSTEM_MSG: S/N[REDACTED]-MAC[RE:DA:CT:ED] - Command is : terminal dont-ask ; terminal password <removed> copy tftp://192.168.1.1/var/lib/tftpboot/poap.cfg.md5 bootflash:/poap.cfg.md5.tmp vrf default - script.sh

What we're really looking for (instead of "copy tftp://192.168.1.1/var/lib/tftpboot/poap.cfg.md5 bootflash:/poap.cfg.md5.tmp vrf default") is something like "copy tftp://192.168.1.1/poap.cfg.md5 bootflash:/poap.cfg.md5.tmp vrf default"

This is because those files in the TFTP (or SCP or FTP) root should be exposed directly to the user by default.