### PR TITLE
Minor change to MD5 update shell command

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -2,8 +2,8 @@
 #md5sum="a39fc249d01b49ddee8c119275eaace7"
 """
 If any changes are made to this script, please run the below command
-in bash shell to update the above md5sum. This is used for integrity check.
-f=poap_nexus_script.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
+in bash shell to update the above md5sum. This is used for an integrity check.
+f=poap.py ; cat $f | sed '/^#md5sum/d' > $f.md5 ; sed -i \
 "s/^#md5sum=.*/#md5sum=\"$(md5sum $f.md5 | sed 's/ .*//')\"/" $f
 """
 


### PR DESCRIPTION
Since the filename is poap.py, it only makes sense to use the filename poap.py in the given bash shell script. That way, the user can copy out the line exactly and run it verbatim to update the MD5 hash in the file.