### PR TITLE
Change copy command not to require username and password for TFTP transfer

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -833,10 +833,15 @@ def do_copy(source="", dest="", login_timeout=10, dest_tmp=""):
                     raise
         else:
             # Add the destination path
-            copy_cmd = "terminal dont-ask ; terminal password %s ; " % password
-            copy_cmd += "copy %s://%s@%s%s %s vrf %s" % (
-                protocol, user, host, source, copy_tmp, vrf)
-            poap_log("Command is : %s" % copy_cmd)
+            if protocol == "tftp":
+                copy_cmd = "terminal dont-ask ; "
+                copy_cmd += "copy %s://%s%s %s vrf %s" % (
+                    protocol, host, source, copy_tmp, vrf)
+            else:
+                copy_cmd = "terminal dont-ask ; terminal password %s ; " % password
+                copy_cmd += "copy %s://%s@%s%s %s vrf %s" % (
+                    protocol, user, host, source, copy_tmp, vrf)
+                poap_log("Command is : %s" % copy_cmd)
             try:
                 cli(copy_cmd)
             except Exception as e:


### PR DESCRIPTION
TFTP does not require a username and password. It does not use any authentication mechanism. The script has been modified to update the copy function:

Rather than "terminal dont-ask ; terminal password <removed> ; copy tftp://tftp@192.168.1.1/poap.cfg.md5 bootflash:/poap.cfg.md5.tmp", we simply want "terminal dont-ask  ; copy tftp://192.168.1.1/poap.cfg.md5 bootflash:/poap.cfg.md5.tmp".

This is the correct CLI and has been validated on a Nexus switch. This is only for the TFTP protocol, so the modification only needs to be made in that case.