### PR TITLE
Improve POAP via USB experience

### DIFF
--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -1,5 +1,5 @@
 #!/bin/env python3
-#md5sum="eb08329071ac99ccc2739640439152a3"
+#md5sum="92c1d1ebb754217d7adc6812457d7377"
 """
 If any changes are made to this script, please run the below command
 in bash shell to update the above md5sum. This is used for integrity check.

--- a/nx-os/poap/poap.py
+++ b/nx-os/poap/poap.py
@@ -313,10 +313,16 @@ def set_defaults_and_validate_options():
     # Transfer protocol (http, ftp, tftp, scp, etc.)
     set_default("transfer_protocol", "scp")
     # Directory where the config resides
-    set_default("config_path", "/var/lib/tftpboot/")
+    if os.environ.get("POAP_PHASE", None) == "USB":
+        set_default("config_path", "")
+    else:
+        set_default("config_path", "/var/lib/tftpboot/")
     # Target image and its path (single image is default)
     set_default("target_system_image", "")
-    set_default("target_image_path", "/var/lib/tftpboot/")
+    if os.environ.get("POAP_PHASE", None) == "USB":
+        set_default("target_image_path", "")
+    else:
+        set_default("target_image_path", "/var/lib/tftpboot/")
     set_default("target_kickstart_image", "")
     # Destination image and its path
     set_default("destination_path", "/bootflash/")
@@ -331,8 +337,10 @@ def set_defaults_and_validate_options():
     set_default("https_ignore_certificate", False)
     
     # User app path
-    set_default("user_app_path", "/var/lib/tftpboot/")
-
+    if os.environ.get("POAP_PHASE", None) == "USB":
+        set_default("user_app_path", "")
+    else:
+        set_default("user_app_path", "/var/lib/tftpboot/")
     # MD5 Verification
     set_default("disable_md5", False)
 
@@ -2664,4 +2672,3 @@ if __name__ == "__main__":
                      .format(fname, exc_tb.tb_lineno))
             exc_tb = exc_tb.tb_next
         abort()
-


### PR DESCRIPTION
This fixes the default path variables when using POAP via USB, so the root directory gets used.

Prior this change, it tries to use `/usbslot1//var/lib/tftpboot/` as config and target image path
```
INFO: Starting Copy of Config File to /bootflash/poap_conf.cfg - /script.sh
Copying file options source=/var/lib/tftpboot/conf.SNSNSNSNSN destination=/bootflash/poap_conf.cfg login_timeout=120 destination_tmp=poap_conf.cfg.tmp - /script.sh
/usbslot1//var/lib/tftpboot/conf.SNSNSNSNSN does NOT exist - /script.sh
```

```
INFO: Starting Copy of System Image - /script.sh
Copying file options source=/var/lib/tftpboot/nxos64-cs.10.4.4.M.bin destination=/bootflash/nxos64-cs.10.4.4.M.bin login_timeout=2100 destination_tmp=nxos64-cs.10.4.4.M.bin.tmp - /script.sh
/usbslot1//var/lib/tftpboot/nxos64-cs.10.4.4.M.bin does NOT exist - /script.sh
Cleanup all files - /script.sh
```